### PR TITLE
modal autofocus機能を実装

### DIFF
--- a/src/modals/modal-alert.pug
+++ b/src/modals/modal-alert.pug
@@ -5,7 +5,7 @@ modal-alert.s-full.t0.l0.f.fh.p19(spat-animation="scale")
     div.main.p16
       div.fs14.white-space-pre-wrap {opts.text}
     div.footer.f.fr.p16
-      button.button.primary.px30.rounded-2.fs16(onclick="{close}") OK
+      button.button.primary.px30.rounded-2.fs16(ref="autofocus", onclick="{close}") OK
 
   style(scoped, type='less').
     :scope {

--- a/src/modals/modal-confirm.pug
+++ b/src/modals/modal-confirm.pug
@@ -6,7 +6,7 @@ modal-confirm.s-full.t0.l0.f.fh.p19(spat-animation="scale")
       div.fs14 {opts.text}
     div.footer.f.fr.p16
       button.button.px30.rounded-2.fs16.mr8(onclick="{close}") cancel
-      button.button.primary.px30.rounded-2.fs16(onclick="{confirm}") OK
+      button.button.primary.px30.rounded-2.fs16(ref="autofocus", onclick="{confirm}") OK
 
   style(scoped, type='less').
     :scope {

--- a/src/modals/spat-modal-actionsheet.pug
+++ b/src/modals/spat-modal-actionsheet.pug
@@ -2,10 +2,10 @@ spat-modal-actionsheet(spat-animation='bottom')
   div.modal(ref='modal')
     div.spat-modal-content
       div.spat-modal-title(if='{opts.title}') {opts.title}
-      div.spat-modal-button(each='{opts.buttons}', class='{style}', onclick='{select}') {label}
+      button.block.w-full.spat-modal-button(each='{opts.buttons}', class='{style}', onclick='{select}', ref='{autofocus ? "autofocus" : null}') {label}
 
     div.spat-modal-footer
-      div.spat-modal-button(onclick='{close}') Cancel
+      button.block.w-full.spat-modal-button(onclick='{close}') Cancel
   style(scoped, type='less').
     :scope {
       display: flex;

--- a/src/spat-modal.pug
+++ b/src/spat-modal.pug
@@ -100,6 +100,19 @@ spat-modal(show='{visible}')
       };
       tag.update();
 
+      document.activeElement && document.activeElement.blur();
+      setTimeout(function() {
+        var autofocus = tag.refs.autofocus && tag.refs.autofocus;
+        if (autofocus) {
+          if (autofocus.focus) {
+            autofocus.focus();
+          }
+          else {
+            autofocus.root && autofocus.root.focus && autofocus.root.focus();
+          }
+        }
+      }, 1);
+
       self.visible = true;
       self.update();
 

--- a/src/spat-modal.pug
+++ b/src/spat-modal.pug
@@ -106,12 +106,10 @@ spat-modal(show='{visible}')
       setTimeout(function() {
         var autofocus = tag.refs.autofocus && tag.refs.autofocus;
         if (autofocus) {
-          if (autofocus.focus) {
-            autofocus.focus();
+          while (autofocus.refs && autofocus.refs.autofocus) {
+            autofocus = autofocus.refs.autofocus;
           }
-          else {
-            autofocus.root && autofocus.root.focus && autofocus.root.focus();
-          }
+          autofocus.focus();
         }
       }, 1);
 

--- a/src/spat-modal.pug
+++ b/src/spat-modal.pug
@@ -104,7 +104,7 @@ spat-modal(show='{visible}')
       tag.update();
 
       setTimeout(function() {
-        var autofocus = tag.refs.autofocus && tag.refs.autofocus;
+        var autofocus = tag.refs.autofocus;
         if (autofocus) {
           while (autofocus.refs && autofocus.refs.autofocus) {
             autofocus = autofocus.refs.autofocus;

--- a/src/spat-modal.pug
+++ b/src/spat-modal.pug
@@ -95,12 +95,14 @@ spat-modal(show='{visible}')
         }
       };
 
+      var prevFocusElement = document.activeElement;
+      prevFocusElement && prevFocusElement.blur();
       tag.close = function() {
         self._closeModal(tag);
+        prevFocusElement && prevFocusElement.focus();
       };
       tag.update();
 
-      document.activeElement && document.activeElement.blur();
       setTimeout(function() {
         var autofocus = tag.refs.autofocus && tag.refs.autofocus;
         if (autofocus) {

--- a/test/index.html
+++ b/test/index.html
@@ -53,7 +53,7 @@ app
         title: 'Change the status of notes',
         subtitle: 'sub title',
         buttons: [
-          { label: 'Publish notes', style: 'normal' },
+          { label: 'Publish notes', style: 'normal', autofocus: true },
           { label: 'secret', style: 'disable' },
           { label: 'static', style: 'normal' },
           { label: 'delete', style: 'danger' },

--- a/test/index.html
+++ b/test/index.html
@@ -105,7 +105,7 @@ modal-sidemenu(spat-animation='left')
       div item3
       div item4
       div item5
-
+      modal-autofocus-test(ref='autofocus')
   style(scoped, type='less').
     :scope {
       display: flex;
@@ -118,6 +118,16 @@ modal-sidemenu(spat-animation='left')
       }
     }
 
+modal-autofocus-test
+  button.block.w-full.text-left(ref='autofocus', onclick='{alert}') OK
+  style(type='less').
+    :scope {
+      display: block;
+    }
+  script.
+    this.alert = function() {
+      spat.modal.alert('TEST');
+    };
 </script>
 <script>
 


### PR DESCRIPTION
- `ref="autofocus"` で モーダルを開いたときに最初にフォーカスしておく要素を指定できるようにしました。
- また、モーダルを開いたときには必ず現在のフォーカスしている要素からを外すようにしました。
- モーダルを閉じたときに、モーダルを開く前にフォーカスしていた要素にフォーカスするようにしました
- autofocus 対象の要素が riot/tag の場合 にも対応しました 書き方は `sidemenu` と `modal-autofocus-test` を参照

## 動作確認
test/index.html で確認
- [ ] 最初に開くアクションシートのPublish notesにフォーカスが合っている
- [ ] alert を開いたらOKボタンにフォーカスが合っている
- [ ] confirm を開いたらOKボタンにフォーカスが合っている
- [ ] sidemenu を開いたときOKボタンにフォーカスが合っている
- [ ] sidemenu のOKボタンで開いたアラートのOKボタンにフォーカスが合っている
- [ ] sidemenu のOKボタンで開いたアラートを閉じたあとにsidemenuのOKボタンにフォーカスが合っている