### PR TITLE
ページ遷移を連続で行った場合ページが表示されなくなるバグ修正

### DIFF
--- a/src/spat-nav.pug
+++ b/src/spat-nav.pug
@@ -174,10 +174,10 @@ spat-nav
 
       // swap animation
       swapAnimation(page, prevPage, this._back).then(function() {
-        // 前のページがあった場合
-        if (prevPage) {
-          prevPage.classList.add('spat-hide');
-        }
+        // 現在のページ以外を非表示にする
+        Array.prototype.forEach.call(self.refs.pages.children, function(page) {
+          if (page !== self.currentPage) page.classList.add('spat-hide');
+        });
 
         self.unlock();
       });


### PR DESCRIPTION
ページ遷移アニメーション中に戻るや進む等で同じページに遷移した際にすべてのページが `spat-hide` で非表示になる問題を修正