### PR TITLE
スワイプバックできるようにする機能を実装

### DIFF
--- a/src/spat-nav.pug
+++ b/src/spat-nav.pug
@@ -1,6 +1,6 @@
 spat-nav
-  div.spat-pages(ref='pages', onmousedown='{swipestart}', onmousemove='{swipe}', onmouseup='{swipeend}', ontouchstart='{swipestart}', ontouchmove='{swipe}', ontouchend='{swipeend}', ondragend='{swipeend}')
-  div.spat-lock(show='{_locked}', ref='lock', onmousemove='{swipe}', onmouseup='{swipeend}')
+  div.spat-pages(ref='pages', onmousedown='{_swipestart}', onmousemove='{_swipe}', onmouseup='{_swipeend}', ontouchstart='{_swipestart}', ontouchmove='{_swipe}', ontouchend='{_swipeend}', ondragend='{_swipeend}')
+  div.spat-lock(show='{_locked}', ref='lock', onmousemove='{_swipe}', onmouseup='{_swipeend}')
 
   style(scoped, type='less').
     :scope {
@@ -252,7 +252,7 @@ spat-nav
       return this;
     };
 
-    this.swipestart = function(e) {
+    this._swipestart = function(e) {
       e.preventUpdate = true;
       if (self._locked || !self.currentPage.dataset.backId || e.defaultPrevented) {
         return ;
@@ -266,7 +266,7 @@ spat-nav
       //- }
     };
 
-    this.swipe = function(e) {
+    this._swipe = function(e) {
       e.preventUpdate = true;
       if (!self._holdSwipe || e.defaultPrevented) {
         return ;
@@ -285,14 +285,14 @@ spat-nav
         if (self._swipeAnimation) {
           e.preventDefault();
           e.stopPropagation();
-          self.updatePageSwipe();
+          self._updatePageSwipe();
           return ;
         }
         // スワイプ中に一定以上スワイプしたら、ページ自体を transform で動くようにする
         if (self.dx > self.swipeThreshold) {
           self._swipeAnimation = true;
           e.preventDefault();
-          self.startPageSwipe();
+          self._startPageSwipe();
         }
         return ;
       }
@@ -312,7 +312,7 @@ spat-nav
       
     };
 
-    this.swipeend = function(e) {
+    this._swipeend = function(e) {
       e.preventUpdate = true;
       self.currentFinger = null;
       if (!self._holdSwipe || !self._swipeAnimation) {
@@ -328,7 +328,7 @@ spat-nav
       var page = self.currentPage;
       var style = page.style;
       style.transition = '256ms';
-      var back = self.checkSwipeBack();
+      var back = self._checkSwipeBack();
       // 少しでも数値が変わらないと transitionend が発火しないので -0.1 にしている
       var x = back ? '100%' : '-0.1px';
       style.transform = 'translateX(' + x + ')';
@@ -353,7 +353,7 @@ spat-nav
       });
     };
 
-    this.startPageSwipe = function() {
+    this._startPageSwipe = function() {
       var page = self.currentPage;
       var style = page.style;
       style.boxShadow = '0 0 100vw -1px rgba(0, 0, 0, 0.5)';
@@ -362,11 +362,11 @@ spat-nav
       self.lock();
     };
 
-    this.updatePageSwipe = function() {
+    this._updatePageSwipe = function() {
       self.currentPage.style.transform = 'translateX(' + Math.max(self.dx, 0) + 'px)';
     };
 
-    this.checkSwipeBack = function() {
+    this._checkSwipeBack = function() {
       var SWIPE_WIDTH_THRESHOLD = 0.5;
       var SWIPE_SPEED_THRESHOLD = 10;
       var rate = self.dx / (innerWidth * SWIPE_WIDTH_THRESHOLD);

--- a/src/spat-nav.pug
+++ b/src/spat-nav.pug
@@ -13,9 +13,11 @@ spat-nav
         position: absolute;
         width: 100%;
         height: 100%;
+        z-index: 0;
 
         .spat-page {
           position: absolute;
+          z-index: 0;
           width: 100%;
           height: 100%;
           backface-visibility: hidden;
@@ -87,7 +89,8 @@ spat-nav
     this._back = false;
     this._locked = false;
     this._autoRender = true;
-    this.edgeSwipeWidth = 30;
+    //- this.edgeSwipeWidth = 30;
+    this.swipeThreshold = 10;
 
     this.on('mount', function() {
       var pages = self.refs.pages;
@@ -107,16 +110,20 @@ spat-nav
       this.update();
     };
 
+    this.getPage = function(pageId) {
+      return this.refs.pages.querySelector('[data-page-id="' + pageId + '"]');
+    };
+
     this.swap = function(tagName, opts) {
       var prevPage = this.currentPage;
 
       // 現在の url を page id としてキャッシュ判定する
       var pageId = location.href.replace(location.origin, '');
       // マウント済みのページを取得
-      var page = this.refs.pages.querySelector('[data-page-id="' + pageId + '"]');
+      var page = self.getPage(pageId);
       // キャッシュフラグ
       var cached = false;
-
+      
       // まだマウントされていなければ新たにマウントする
       if(page === null) {
         page = document.createElement('div');
@@ -135,6 +142,13 @@ spat-nav
           parent.appendChild(page);
         }
       };
+
+      if (!self._back && prevPage) {
+        // 戻る先の pageId をキャッシュしておく
+        page.dataset.backId = prevPage.dataset.pageId;
+        // 進むが実装されるときに参照する用
+        prevPage.dataset.nextId = pageId;
+      }
 
       // 画面をロック
       this.lock();
@@ -178,16 +192,24 @@ spat-nav
       page.classList.remove('spat-hide');
 
       // swap animation
-      swapAnimation(page, prevPage, this._back).then(function() {
+      var swapPromise = self._swipeBack ? Promise.resolve() : swapAnimation(page, prevPage, this._back);
+      
+      swapPromise.then(function() {
         // 現在のページ以外を非表示にする
         Array.prototype.forEach.call(self.refs.pages.children, function(page) {
           if (page !== self.currentPage) page.classList.add('spat-hide');
         });
 
+        // 最前面に移動
+        var parent = page.parentNode;
+        parent.removeChild(page);
+        parent.appendChild(page);
+
         self.unlock();
       });
 
       self._back = false;
+      self._swipeBack = false;
 
       this.currentPage = page;
       this.prevPage = prevPage;
@@ -230,21 +252,21 @@ spat-nav
 
     this.swipestart = function(e) {
       e.preventUpdate = true;
-      if (!self.prevPage) {
+      if (self._locked || !self.currentPage.dataset.backId || e.defaultPrevented) {
         return ;
       }
       var p = self.toPoint(e);
-      if (p.clientX < self.edgeSwipeWidth) {
-        self._holdSwipe = true;
-        self.x = self.sx = self.px = p.clientX;
-        self.y = self.sy = self.py = p.clientY;
-        self.mx = self.my = self.dx = self.dy = 0;
-      }
+      //- if (p.clientX < self.edgeSwipeWidth) {
+      self._holdSwipe = true;
+      self.x = self.sx = self.px = p.clientX;
+      self.y = self.sy = self.py = p.clientY;
+      self.mx = self.my = self.dx = self.dy = 0;
+      //- }
     };
 
     this.swipe = function(e) {
       e.preventUpdate = true;
-      if (!self._holdSwipe) {
+      if (!self._holdSwipe || e.defaultPrevented) {
         return ;
       }
       var p = self.toPoint(e);
@@ -256,10 +278,20 @@ spat-nav
       self.y = p.clientY;
       self.dx = self.x - self.sx;
       self.dy = self.y - self.sy;
-      if (self._edgeSwipe) {
-        e.preventDefault();
-        e.stopPropagation();
-        self.updatePageSwipe();
+      if (self._swiping) {
+        // 動かしているページの座標を更新する
+        if (self._swipeAnimation) {
+          e.preventDefault();
+          e.stopPropagation();
+          self.updatePageSwipe();
+          return ;
+        }
+        // スワイプ中に一定以上スワイプしたら、ページ自体を transform で動くようにする
+        if (self.dx > self.swipeThreshold) {
+          self._swipeAnimation = true;
+          e.preventDefault();
+          self.startPageSwipe();
+        }
         return ;
       }
       var ax = Math.abs(self.dx);
@@ -267,10 +299,10 @@ spat-nav
       if (ax === ay) {
         return ;
       }
+      // 横移動が多かったら、スワイプしていることにする
       if (ax > ay) {
         e.preventDefault();
-        self._edgeSwipe = true;
-        self.startPageSwipe();
+        self._swiping = true;
       }
       else {
         self._holdSwipe = false;
@@ -281,19 +313,19 @@ spat-nav
     this.swipeend = function(e) {
       e.preventUpdate = true;
       self.currentFinger = null;
-      if (!self._holdSwipe) {
+      if (!self._holdSwipe || !self._swipeAnimation) {
+        self._swiping = false;
+        self._holdSwipe = false;
         return ;
       }
-      if (self._edgeSwipe) {
-        e.preventDefault();
-        e.stopPropagation();
-      }
+      e.preventDefault();
+      e.stopPropagation();
+      self._swipeAnimation = false;
       self._holdSwipe = false;
-      self._edgeSwipe = false;
-      self.lock();
+      self._swiping = false;
       var page = self.currentPage;
       var style = page.style;
-      style.transition = self.animationDuration || '256ms';
+      style.transition = '256ms';
       var back = self.checkSwipeBack();
       // 少しでも数値が変わらないと transitionend が発火しないので -0.1 にしている
       var x = back ? '100%' : '-0.1px';
@@ -304,11 +336,11 @@ spat-nav
       onceEvent(page, 'transitionend', function() {
         if (back) {
           page.classList.add('spat-hide');
-          // TODO: うまくやる
+          self._swipeBack = true;
           spat.nav.back();
         }
         else {
-          self.prevPage.classList.add('spat-hide');
+          self.getPage(page.dataset.backId).classList.add('spat-hide');
         }
         style.removeProperty('opacity');
         style.removeProperty('transform');
@@ -320,9 +352,11 @@ spat-nav
     };
 
     this.startPageSwipe = function() {
-      self.currentPage.style.boxShadow = '0 0 100vw -1px rgba(0, 0, 0, 0.5)';
-      self.currentPage.style.opacity = '1';
-      self.prevPage.classList.remove('spat-hide');
+      var page = self.currentPage;
+      var style = page.style;
+      style.boxShadow = '0 0 100vw -1px rgba(0, 0, 0, 0.5)';
+      style.opacity = '1';
+      self.getPage(page.dataset.backId).classList.remove('spat-hide');
       self.lock();
     };
 

--- a/src/spat-nav.pug
+++ b/src/spat-nav.pug
@@ -110,10 +110,6 @@ spat-nav
       this.update();
     };
 
-    this.getPage = function(pageId) {
-      return this.refs.pages.querySelector('[data-page-id="' + pageId + '"]');
-    };
-
     this.swap = function(tagName, opts) {
       var prevPage = this.currentPage;
 
@@ -143,13 +139,6 @@ spat-nav
         }
       };
 
-      if (!self._back && prevPage) {
-        // 戻る先の pageId をキャッシュしておく
-        page.dataset.backId = prevPage.dataset.pageId;
-        // 進むが実装されるときに参照する用
-        prevPage.dataset.nextId = pageId;
-      }
-
       // 画面をロック
       this.lock();
 
@@ -171,6 +160,11 @@ spat-nav
           }
         },
       };
+      delete page.dataset.canBack;
+      delete page.dataset.canForward;
+      delete page.dataset.backId;
+      delete page.dataset.nextId;
+      this.trigger('swap', e);
       page._tag.trigger('show', e);
       page._tag.update();
 
@@ -179,12 +173,22 @@ spat-nav
         prevPage._tag.update();
       }
 
-      this.trigger('swap', {
-      });
-
       if (this._autoRender) {
         this._swap(page, prevPage);
       }
+    };
+
+    this.setupPageSwipe = function(page, data) {
+      data = data || {};
+      if (data.canBack) {
+        page.dataset.canBack = 'true';
+      }
+      if (data.canForward) {
+        page.dataset.canForward = 'true';
+      }
+      page.dataset.backId = data.backId;
+      page.dataset.nextId = data.nextId;
+      return this;
     };
 
     this._swap = function(page, prevPage) {
@@ -192,7 +196,7 @@ spat-nav
       page.classList.remove('spat-hide');
 
       // swap animation
-      var swapPromise = self._swipeBack ? Promise.resolve() : swapAnimation(page, prevPage, this._back);
+      var swapPromise = self.disableSwapAnimation ? Promise.resolve() : swapAnimation(page, prevPage, this._back);
       
       swapPromise.then(function() {
         // 現在のページ以外を非表示にする
@@ -211,7 +215,7 @@ spat-nav
       });
 
       self._back = false;
-      self._swipeBack = false;
+      self.disableSwapAnimation = false;
 
       this.currentPage = page;
       this.prevPage = prevPage;
@@ -254,7 +258,8 @@ spat-nav
 
     this._swipestart = function(e) {
       e.preventUpdate = true;
-      if (self._locked || !self.currentPage.dataset.backId || e.defaultPrevented) {
+      if (self._locked || !self.currentPage.dataset.canBack || e.defaultPrevented) {
+        self.cancelSwipe();
         return ;
       }
       var p = self.toPoint(e);
@@ -269,6 +274,7 @@ spat-nav
     this._swipe = function(e) {
       e.preventUpdate = true;
       if (!self._holdSwipe || e.defaultPrevented) {
+        self.cancelSwipe();
         return ;
       }
       var p = self.toPoint(e);
@@ -290,8 +296,8 @@ spat-nav
         }
         // スワイプ中に一定以上スワイプしたら、ページ自体を transform で動くようにする
         if (self.dx > self.swipeThreshold) {
-          self._swipeAnimation = true;
           e.preventDefault();
+          e.stopPropagation();
           self._startPageSwipe();
         }
         return ;
@@ -304,6 +310,7 @@ spat-nav
       // 横移動が多かったら、スワイプしていることにする
       if (ax > ay) {
         e.preventDefault();
+        e.stopPropagation();
         self._swiping = true;
       }
       else {
@@ -312,23 +319,32 @@ spat-nav
       
     };
 
-    this._swipeend = function(e) {
-      e.preventUpdate = true;
+    // スワイプしてない状態にする。 _releaseSwipe をしないといけない場合に true を返す
+    this._resetSwipe = function() {
       self.currentFinger = null;
       if (!self._holdSwipe || !self._swipeAnimation) {
-        self._swiping = false;
+        self._swipeAnimation = false;
         self._holdSwipe = false;
+        self._swiping = false;
+        if (self._locked) {
+          self.unlock();
+        }
         return ;
       }
-      e.preventDefault();
-      e.stopPropagation();
+      return true;
+    };
+
+    this._releaseSwipe = function(back) {
+      if (back === undefined) {
+        back = self._checkSwipeBack();
+      }
       self._swipeAnimation = false;
       self._holdSwipe = false;
       self._swiping = false;
-      var page = self.currentPage;
+      var page = self._swipePage;
+      self._swipePage = null;
       var style = page.style;
       style.transition = '256ms';
-      var back = self._checkSwipeBack();
       // 少しでも数値が変わらないと transitionend が発火しないので -0.1 にしている
       var x = back ? '100%' : '-0.1px';
       style.transform = 'translateX(' + x + ')';
@@ -338,11 +354,14 @@ spat-nav
       onceEvent(page, 'transitionend', function() {
         if (back) {
           page.classList.add('spat-hide');
-          self._swipeBack = true;
-          spat.nav.back();
+          self.disableSwapAnimation = true;
+          self.trigger('swipebackend');
         }
         else {
-          self.getPage(page.dataset.backId).classList.add('spat-hide');
+          var backPage = self.getPage(page.dataset.backId);
+          if (backPage && self.currentPage !== backPage) {
+            backPage.classList.add('spat-hide');
+          }
         }
         style.removeProperty('opacity');
         style.removeProperty('transform');
@@ -353,17 +372,37 @@ spat-nav
       });
     };
 
+    this._swipeend = function(e) {
+      e.preventUpdate = true;
+      if (self._resetSwipe()) {
+        e.preventDefault();
+        e.stopPropagation();
+        self._releaseSwipe();
+      }
+    };
+    
+    this.cancelSwipe = function() {
+      if (self._resetSwipe()) {
+        self._releaseSwipe(false);
+      }
+    };
+
     this._startPageSwipe = function() {
-      var page = self.currentPage;
+      self.trigger('swipebackstart');
+      self._swipeAnimation = true;
+      var page = self._swipePage = self.currentPage;
       var style = page.style;
       style.boxShadow = '0 0 100vw -1px rgba(0, 0, 0, 0.5)';
       style.opacity = '1';
-      self.getPage(page.dataset.backId).classList.remove('spat-hide');
+      var backPage = self.getPage(page.dataset.backId);
+      if (backPage) {
+        backPage.classList.remove('spat-hide');
+      }
       self.lock();
     };
 
     this._updatePageSwipe = function() {
-      self.currentPage.style.transform = 'translateX(' + Math.max(self.dx, 0) + 'px)';
+      self._swipePage.style.transform = 'translateX(' + Math.max(self.dx, 0) + 'px)';
     };
 
     this._checkSwipeBack = function() {
@@ -391,6 +430,10 @@ spat-nav
       else {
         return e;
       }
+    };
+
+    this.getPage = function(pageId) {
+      return self.refs.pages.querySelector('[data-page-id="' + pageId + '"]');
     };
 
     window.spat.nav = this;

--- a/src/spat-nav.pug
+++ b/src/spat-nav.pug
@@ -113,7 +113,8 @@ spat-nav
       this.refs.lock.style.backgroundColor = '';
       this.update();
     };
-
+    
+    // pageId に一致するページを取得する
     this.getPage = function(pageId) {
       return self.refs.pages.querySelector('[data-page-id="' + pageId + '"]');
     };
@@ -145,6 +146,7 @@ spat-nav
           var parent = page.parentNode;
           parent.removeChild(page);
           parent.appendChild(page);
+          // z-index の前後関係を調整
           page.classList.add('current');
         }
       };
@@ -188,7 +190,15 @@ spat-nav
       }
     };
 
-    // ページをスワイプしたい場合に設定する
+    /**
+     * ページをスワイプしたい場合に設定する
+     * page 対象のページ
+     * data page に設定したいスワイプに関するプロパティ
+     * data.canBack 左から右の方向にスワイプさせたい時に設定する
+     * data.canForward 右から左の方向にスワイプさせたいときに設定する (未実装)
+     * data.backId canBack の場合 pageId を設定すると、 スワイプ中に背面にそのページが表示される
+     * data.nextId canForward の場合 pageId を設定すると、 スワイプ中に前面にそのページが表示される (未実装)
+     */
     this.setupPageSwipe = function(page, data) {
       data = data || {};
       if (data.canBack) {
@@ -266,13 +276,16 @@ spat-nav
       return this;
     };
 
+    // スワイプ開始時の処理
     this._swipestart = function(e) {
       e.preventUpdate = true;
+      // _locked か canBack が設定されてない場合か、イベントのデフォルト処理が無効化されているときは何もしない
       if (self._locked || !self.currentPage.dataset.canBack || e.defaultPrevented) {
         self.cancelSwipe();
         return ;
       }
       var p = self.toPoint(e);
+      // タッチした範囲がスワイプ対象の範囲内の場合は、ホールド状態にする
       if (p.clientX < innerWidth * self.swipeWidthRate) {
         self._holdSwipe = true;
         self.x = self.sx = self.px = p.clientX;
@@ -281,8 +294,10 @@ spat-nav
       }
     };
 
+    // スワイプ中の処理
     this._swipe = function(e) {
       e.preventUpdate = true;
+      // スワイプがホールドされてないときか、イベントのデフォルト処理が無効化されているときは何もしない
       if (!self._holdSwipe || e.defaultPrevented) {
         self.cancelSwipe();
         return ;
@@ -296,8 +311,10 @@ spat-nav
       self.y = p.clientY;
       self.dx = self.x - self.sx;
       self.dy = self.y - self.sy;
+
+      // スワイプ中の処理
       if (self._swiping) {
-        // 動かしているページの座標を更新する
+        // 一定以上スワイプしている場合、動かしているページの座標を更新する
         if (self._swipeAnimation) {
           e.preventDefault();
           e.stopPropagation();
@@ -312,12 +329,15 @@ spat-nav
         }
         return ;
       }
+
+      // ホールドはしているが、スワイプはしてないときの処理
       var ax = Math.abs(self.dx);
       var ay = Math.abs(self.dy);
+      // 移動量が同じ場合は、 0 === 0 の場合を考慮して、値がずれるまでは何もしない
       if (ax === ay) {
         return ;
       }
-      // 横移動が多かったら、スワイプしていることにする
+      // 横移動が多かったら、スワイプ中にする
       if (ax > ay) {
         e.preventDefault();
         e.stopPropagation();
@@ -344,6 +364,12 @@ spat-nav
       return true;
     };
 
+    /** 
+     * スワイプを終了し、ページを特定の位置へ移動させる処理
+     * スワイプが一定以上であれば、左か右へ移動させる
+     * スワイプが一定未満であれば、元の位置へ戻す
+     * back スワイプバックかどうかの判定を固定で指定したい場合に設定
+     */
     this._releaseSwipe = function(back) {
       if (back === undefined) {
         back = self._checkSwipeBack();
@@ -382,6 +408,7 @@ spat-nav
       });
     };
 
+    // ページからポインタを離したときの処理
     this._swipeend = function(e) {
       e.preventUpdate = true;
       if (self._resetSwipe()) {
@@ -398,6 +425,7 @@ spat-nav
       }
     };
 
+    // スワイプ中のページの座標を移動させるための前処理
     this._startPageSwipe = function() {
       self.trigger('swipebackstart');
       self._swipeAnimation = true;
@@ -412,10 +440,12 @@ spat-nav
       self.lock();
     };
 
+    // スワイプ中のページの座標を更新する
     this._updatePageSwipe = function() {
       self._swipePage.style.transform = 'translateX(' + Math.max(self.dx, 0) + 'px)';
     };
 
+    // 現時点でのスワイプ量がスワイプバックと判定されるかどうか
     this._checkSwipeBack = function() {
       var SWIPE_WIDTH_THRESHOLD = 0.5;
       var SWIPE_SPEED_THRESHOLD = 10;
@@ -424,6 +454,7 @@ spat-nav
       return rate > 1;
     };
 
+    // マウス、タッチのどちらでも共通のプロパティで、座標にアクセスできるようにする
     this.toPoint = function(e) {
       var touches = e.changedTouches;
       // SP

--- a/src/spat-nav.pug
+++ b/src/spat-nav.pug
@@ -202,8 +202,10 @@ spat-nav
 
         // 最前面に移動
         var parent = page.parentNode;
-        parent.removeChild(page);
-        parent.appendChild(page);
+        if (parent.lastChildElement !== page) {
+          parent.removeChild(page);
+          parent.appendChild(page);
+        }
 
         self.unlock();
       });

--- a/src/spat-nav.pug
+++ b/src/spat-nav.pug
@@ -1,6 +1,6 @@
 spat-nav
-  div.spat-pages(ref='pages')
-  div.spat-lock(show='{_locked}', ref='lock')
+  div.spat-pages(ref='pages', onmousedown='{swipestart}', onmousemove='{swipe}', onmouseup='{swipeend}', ontouchstart='{swipestart}', ontouchmove='{swipe}', ontouchend='{swipeend}')
+  div.spat-lock(show='{_locked}', ref='lock', onmousemove='{swipe}', onmouseup='{swipeend}', ontouchmove='{swipe}', ontouchend='{swipeend}')
 
   style(scoped, type='less').
     :scope {
@@ -87,6 +87,11 @@ spat-nav
     this._back = false;
     this._locked = false;
     this._autoRender = true;
+    this.edgeSwipeWidth = 30;
+
+    this.on('mount', function() {
+      var pages = self.refs.pages;
+    });
 
     this.lock = function(color) {
       this._locked = true;
@@ -221,6 +226,132 @@ spat-nav
         this.currentPage.setAttribute('data-page-id', pageId);
       }
       return this;
+    };
+
+    this.swipestart = function(e) {
+      e.preventUpdate = true;
+      if (!self.prevPage) {
+        return ;
+      }
+      var p = self.toPoint(e);
+      if (p.clientX < self.edgeSwipeWidth) {
+        self._holdSwipe = true;
+        self.x = self.sx = self.px = p.clientX;
+        self.y = self.sy = self.py = p.clientY;
+      }
+    };
+
+    this.swipe = function(e) {
+      e.preventUpdate = true;
+      if (!self._holdSwipe) {
+        return ;
+      }
+      var p = self.toPoint(e);
+      self.mx = p.clientX - self.px;
+      self.my = p.clientY - self.py;
+      self.px = self.x;
+      self.py = self.y;
+      self.x = p.clientX;
+      self.y = p.clientY;
+      self.dx = self.x - self.sx;
+      self.dy = self.y - self.sy;
+      if (self._edgeSwipe) {
+        e.preventDefault();
+        e.stopPropagation();
+        self.updatePageSwipe();
+        return ;
+      }
+      var ax = Math.abs(self.dx);
+      var ay = Math.abs(self.dy);
+      if (ax === ay) {
+        return ;
+      }
+      if (ax > ay) {
+        e.preventDefault();
+        self._edgeSwipe = true;
+        self.startPageSwipe();
+      }
+      else {
+        self._holdSwipe = false;
+      }
+      
+    };
+
+    this.swipeend = function(e) {
+      e.preventUpdate = true;
+      self.currentFinger = null;
+      if (!self._holdSwipe) {
+        return ;
+      }
+      self._holdSwipe = false;
+      self._edgeSwipe = false;
+      self.lock();
+      e.preventDefault();
+      e.stopPropagation();
+      var page = self.currentPage;
+      var style = page.style;
+      style.transition = self.animationDuration || '256ms';
+      var back = self.checkSwipeBack();
+      // 少しでも数値が変わらないと transitionend が発火しないので -0.1 にしている
+      var x = back ? '100%' : '-0.1px';
+      style.transform = 'translateX(' + x + ')';
+      if (back) {
+        style.opacity = '0';
+      }
+      onceEvent(page, 'transitionend', function() {
+        if (back) {
+          page.classList.add('spat-hide');
+          // TODO: うまくやる
+          spat.nav.back();
+        }
+        else {
+          self.prevPage.classList.add('spat-hide');
+        }
+        style.removeProperty('opacity');
+        style.removeProperty('transform');
+        style.removeProperty('transition');
+        style.removeProperty('box-shadow');
+        
+        self.unlock();
+      });
+    };
+
+    this.startPageSwipe = function() {
+      self.currentPage.style.boxShadow = '0 0 100vw -1px rgba(0, 0, 0, 0.5)';
+      self.currentPage.style.opacity = '1';
+      self.prevPage.classList.remove('spat-hide');
+      self.lock();
+    };
+
+    this.updatePageSwipe = function() {
+      self.currentPage.style.transform = 'translateX(' + Math.max(self.dx, 0) + 'px)';
+    };
+
+    this.checkSwipeBack = function() {
+      var SWIPE_WIDTH_THRESHOLD = 0.5;
+      var SWIPE_SPEED_THRESHOLD = 10;
+      var rate = self.dx / (innerWidth * SWIPE_WIDTH_THRESHOLD);
+      rate += self.mx / SWIPE_SPEED_THRESHOLD;
+      return rate > 1;
+    };
+
+    this.toPoint = function(e) {
+      var touches = e.changedTouches;
+      // SP
+      if (touches) {
+        if (!self.currentFinger) {
+          return self.currentFinger = touches[0];
+        }
+        else {
+          return Array.prototype.find.call(touches, function(touch) {
+            return touch.identifier === self.currentFinger.identifier;
+          });
+        }
+      }
+      // PC
+      else {
+        return e;
+      }
     };
 
     window.spat.nav = this;

--- a/src/spat-nav.pug
+++ b/src/spat-nav.pug
@@ -1,6 +1,6 @@
 spat-nav
   div.spat-pages(ref='pages', onmousedown='{swipestart}', onmousemove='{swipe}', onmouseup='{swipeend}', ontouchstart='{swipestart}', ontouchmove='{swipe}', ontouchend='{swipeend}')
-  div.spat-lock(show='{_locked}', ref='lock', onmousemove='{swipe}', onmouseup='{swipeend}', ontouchmove='{swipe}', ontouchend='{swipeend}')
+  div.spat-lock(show='{_locked}', ref='lock', onmousemove='{swipe}', onmouseup='{swipeend}')
 
   style(scoped, type='less').
     :scope {

--- a/src/spat-nav.pug
+++ b/src/spat-nav.pug
@@ -238,6 +238,7 @@ spat-nav
         self._holdSwipe = true;
         self.x = self.sx = self.px = p.clientX;
         self.y = self.sy = self.py = p.clientY;
+        self.mx = self.my = self.dx = self.dy = 0;
       }
     };
 

--- a/src/spat-nav.pug
+++ b/src/spat-nav.pug
@@ -133,6 +133,7 @@ spat-nav
         page = document.createElement('div');
         page.classList.add('spat-page');
         page.classList.add('spat-hide');
+        page.classList.add('current');
         page.setAttribute('data-page-id', pageId);
         this.refs.pages.appendChild(page);
         riot.mount(page, tagName);
@@ -144,6 +145,7 @@ spat-nav
           var parent = page.parentNode;
           parent.removeChild(page);
           parent.appendChild(page);
+          page.classList.add('current');
         }
       };
 

--- a/src/spat-nav.pug
+++ b/src/spat-nav.pug
@@ -89,7 +89,7 @@ spat-nav
     this._back = false;
     this._locked = false;
     this._autoRender = true;
-    //- this.edgeSwipeWidth = 30;
+    this.swipeWidthRate = 1;
     this.swipeThreshold = 1;
 
     this.on('mount', function() {
@@ -263,12 +263,12 @@ spat-nav
         return ;
       }
       var p = self.toPoint(e);
-      //- if (p.clientX < self.edgeSwipeWidth) {
-      self._holdSwipe = true;
-      self.x = self.sx = self.px = p.clientX;
-      self.y = self.sy = self.py = p.clientY;
-      self.mx = self.my = self.dx = self.dy = 0;
-      //- }
+      if (p.clientX < innerWidth * self.swipeWidthRate) {
+        self._holdSwipe = true;
+        self.x = self.sx = self.px = p.clientX;
+        self.y = self.sy = self.py = p.clientY;
+        self.mx = self.my = self.dx = self.dy = 0;
+      }
     };
 
     this._swipe = function(e) {

--- a/src/spat-nav.pug
+++ b/src/spat-nav.pug
@@ -25,7 +25,9 @@ spat-nav
           overflow: scroll;
           -webkit-overflow-scrolling: touch;
           overflow-scrolling: touch;
-
+          &.current {
+            z-index: 9999;
+          }
           &.spat-hide {
             display: none;
           }
@@ -208,15 +210,14 @@ spat-nav
       swapPromise.then(function() {
         // 現在のページ以外を非表示にする
         Array.prototype.forEach.call(self.refs.pages.children, function(page) {
-          if (page !== self.currentPage) page.classList.add('spat-hide');
+          if (page !== self.currentPage) {
+            page.classList.add('spat-hide');
+            page.classList.remove('current');
+          }
         });
 
         // 最前面に移動
-        var parent = page.parentNode;
-        if (parent.lastChildElement !== page) {
-          parent.removeChild(page);
-          parent.appendChild(page);
-        }
+        page.classList.add('current');
 
         self.unlock();
       });

--- a/src/spat-nav.pug
+++ b/src/spat-nav.pug
@@ -284,11 +284,13 @@ spat-nav
       if (!self._holdSwipe) {
         return ;
       }
+      if (self._edgeSwipe) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
       self._holdSwipe = false;
       self._edgeSwipe = false;
       self.lock();
-      e.preventDefault();
-      e.stopPropagation();
       var page = self.currentPage;
       var style = page.style;
       style.transition = self.animationDuration || '256ms';

--- a/src/spat-nav.pug
+++ b/src/spat-nav.pug
@@ -1,5 +1,5 @@
 spat-nav
-  div.spat-pages(ref='pages', onmousedown='{swipestart}', onmousemove='{swipe}', onmouseup='{swipeend}', ontouchstart='{swipestart}', ontouchmove='{swipe}', ontouchend='{swipeend}')
+  div.spat-pages(ref='pages', onmousedown='{swipestart}', onmousemove='{swipe}', onmouseup='{swipeend}', ontouchstart='{swipestart}', ontouchmove='{swipe}', ontouchend='{swipeend}', ondragend='{swipeend}')
   div.spat-lock(show='{_locked}', ref='lock', onmousemove='{swipe}', onmouseup='{swipeend}')
 
   style(scoped, type='less').
@@ -90,7 +90,7 @@ spat-nav
     this._locked = false;
     this._autoRender = true;
     //- this.edgeSwipeWidth = 30;
-    this.swipeThreshold = 10;
+    this.swipeThreshold = 1;
 
     this.on('mount', function() {
       var pages = self.refs.pages;

--- a/src/spat-nav.pug
+++ b/src/spat-nav.pug
@@ -89,7 +89,9 @@ spat-nav
     this._back = false;
     this._locked = false;
     this._autoRender = true;
+    // 画面端からスワイプが反応する幅の割合
     this.swipeWidthRate = 1;
+    // スワイプでページが動き始めるために必要な幅(px)
     this.swipeThreshold = 1;
 
     this.on('mount', function() {
@@ -108,6 +110,10 @@ spat-nav
       this._locked = false;
       this.refs.lock.style.backgroundColor = '';
       this.update();
+    };
+
+    this.getPage = function(pageId) {
+      return self.refs.pages.querySelector('[data-page-id="' + pageId + '"]');
     };
 
     this.swap = function(tagName, opts) {
@@ -178,6 +184,7 @@ spat-nav
       }
     };
 
+    // ページをスワイプしたい場合に設定する
     this.setupPageSwipe = function(page, data) {
       data = data || {};
       if (data.canBack) {
@@ -381,6 +388,7 @@ spat-nav
       }
     };
     
+    // スワイプ中にブラウザバックした場合などにスワイプをキャンセルする
     this.cancelSwipe = function() {
       if (self._resetSwipe()) {
         self._releaseSwipe(false);
@@ -430,10 +438,6 @@ spat-nav
       else {
         return e;
       }
-    };
-
-    this.getPage = function(pageId) {
-      return self.refs.pages.querySelector('[data-page-id="' + pageId + '"]');
     };
 
     window.spat.nav = this;

--- a/test/sp.html
+++ b/test/sp.html
@@ -87,6 +87,11 @@ app
     this.on('mount', function() {
       // spat.nav.animationDuration = '1000ms';
       
+      // check back
+      window.addEventListener('popstate', function(e) {
+        spat.nav._back = true;
+      }, false);
+      
       var routeful = Routeful();
       routeful.base('#');
       routeful.root(location.pathname);
@@ -107,10 +112,6 @@ app
       // });
       // route.start(true);
 
-      // // check back
-      // window.addEventListener('popstate', function(e) {
-      //   spat.nav._back = true;
-      // }, false);
     });
 
 home


### PR DESCRIPTION
スワイプバックをするための機能を実装しました
デフォルトでは画面端じゃなくても、どこでもスワイプバックできます
ページが切り替わったタイミングで、戻れるかどうかと、戻り先のpageIdをセットすると使えます
swipebackendでspat.nav.backを呼び出すとページ遷移します
```
spat.nav.on('swap', function(e) {
spat.nav.setupPageSwipe(e.currentPage, {
canBack: 戻れるかのフラグ,
backId: 戻り先のpageId,
});
});
spat.nav.on('swipebackend', function() {spat.nav.back();});
```