### PR TITLE
複数の指で操作した場合のスワイプバック周りの挙動を修正

### DIFF
--- a/src/spat-nav.pug
+++ b/src/spat-nav.pug
@@ -301,7 +301,7 @@ spat-nav
     // スワイプ開始時の処理
     this._swipestart = function(e) {
       e.preventUpdate = true;
-      if (!self.currentPage) {
+      if (!self.currentPage || self._swipeCanceled || self.currentFinger) {
         return ;
       }
       // _locked か canBack が設定されてない場合か、イベントのデフォルト処理が無効化されているときは何もしない
@@ -310,6 +310,7 @@ spat-nav
         return ;
       }
       var p = self.toPoint(e);
+      if (!p) return ;
       var hold = false;
 
       //- 下スワイプ
@@ -333,6 +334,7 @@ spat-nav
     // スワイプ中の処理
     this._swipe = function(e) {
       e.preventUpdate = true;
+      if (self._swipeCanceled) return ;
       if (e.type === 'mousemove' && (e.buttons === 0 || !self._holdSwipe)) {
         return ;
       }
@@ -342,6 +344,7 @@ spat-nav
         return ;
       }
       var p = self.toPoint(e);
+      if (!p) return ;
       self.mx = p.clientX - self.px;
       self.my = p.clientY - self.py;
       self.px = self.x;
@@ -493,6 +496,17 @@ spat-nav
       if (e.type === 'mouseup' && !self._holdSwipe) {
         return ;
       }
+      if (self._swipeCanceled) {
+        if (e.type === 'touchend') {
+          self._swipeCanceled = !!e.touches.length;
+        }
+        if (e.type === 'touchcancel') {
+          self._swipeCanceled = false;
+        }
+        if (self._swipeCanceled) {
+          return ;
+        }
+      }
       if (self._resetSwipe()) {
         e.preventDefault();
         e.stopPropagation();
@@ -502,6 +516,7 @@ spat-nav
     
     // スワイプ中にブラウザバックした場合などにスワイプをキャンセルする
     this.cancelSwipe = function() {
+      self._swipeCanceled = true;
       if (self._resetSwipe()) {
         self._releaseSwipe(false);
       }

--- a/src/spat-nav.pug
+++ b/src/spat-nav.pug
@@ -1,5 +1,5 @@
 spat-nav
-  div.spat-pages(class="{'scrollable': opts.scrollable !== false}", ref='pages', onmousedown='{_swipestart}', onmousemove='{_swipe}', onmouseup='{_swipeend}', ontouchstart='{_swipestart}', ontouchmove='{_swipe}', ontouchend='{_swipeend}', ondragend='{_swipeend}')
+  div.spat-pages(class="{'scrollable': opts.scrollable !== false}", ref='pages', onmousedown='{_swipestart}', onmousemove='{_swipe}', onmouseup='{_swipeend}', ontouchstart='{_swipestart}', ontouchmove='{_swipe}', ontouchend='{_swipeend}', ontouchcancel='{_swipeend}', ondragend='{_swipeend}')
   div.spat-lock(show='{_locked}', ref='lock', onmousemove='{_swipe}', onmouseup='{_swipeend}')
 
   style(scoped, type='less').


### PR DESCRIPTION
- pointがundefinedになるケースを考慮
- スクロールしながら指を離さずにスワイプバック等をできないように変更
- touchcancel (OS割り込みによるタッチのキャンセル等)でスワイプ中に固まったりするのをすべての指を離したとして修正