### PR TITLE
同じページだったとき対策

### DIFF
--- a/src/spat-nav.pug
+++ b/src/spat-nav.pug
@@ -199,7 +199,14 @@ spat-nav
             console.log(Date.now() - d);
           }
         },
+      };
+
+      // prevPage がある場合は hide を呼ぶ
+      if (prevPage) {
+        prevPage._tag.trigger('hide', e);
+        prevPage._tag.update();
       }
+
       page.removeAttribute('data-can-back');
       page.removeAttribute('data-can-forward');
       page.removeAttribute('data-back-id');
@@ -207,11 +214,6 @@ spat-nav
       this.trigger('swap', e);
       page._tag.trigger('show', e);
       page._tag.update();
-
-      if (prevPage) {
-        prevPage._tag.trigger('hide', e);
-        prevPage._tag.update();
-      }
 
       if (this._autoRender) {
         this._swap(page, prevPage);

--- a/src/spat-nav.pug
+++ b/src/spat-nav.pug
@@ -154,6 +154,8 @@ spat-nav
       var cached = false;
       
       // まだマウントされていなければ新たにマウントする
+
+      // キャッシュがなかった場合
       if(page === null) {
         page = document.createElement('div');
         page.classList.add('spat-page');
@@ -166,7 +168,8 @@ spat-nav
       }
       else {
         cached = true;
-        if (!this._back) {
+        // prev と今の page が違った場合は強制的に page を最前面にする
+        if (page !== prevPage && !this._back) {
           // 最前面に移動
           var parent = page.parentNode;
           parent.removeChild(page);


### PR DESCRIPTION
- 同じページだった場合, remove, append による最前面処理をしないようにする
  + スクロールがリセットされる為
- 同じページだった場合, show より hide を先に発火させる
  + show の後に hide が呼ばれないようにする為